### PR TITLE
Add product URLs to Shopee analysis and chatbot UI

### DIFF
--- a/src/app/api/shopee/analyze/route.ts
+++ b/src/app/api/shopee/analyze/route.ts
@@ -133,13 +133,13 @@ async function scrapeShopeeProduct(url: string) {
     if (taskResponse.status === 200) {
       // Immediate result
       console.log('✅ Got immediate result!')
-      return processScrapelessData(taskData)
+      return processScrapelessData(taskData, url)
     } else if (taskResponse.status === 201) {
       // Need to poll for result
       const taskId = taskData.taskId
       console.log('⏳ Polling for result, taskId:', taskId)
 
-      return await pollForResult(taskId)
+      return await pollForResult(taskId, url)
     } else {
       throw new Error(`Unexpected response status: ${taskResponse.status}`)
     }
@@ -154,7 +154,7 @@ async function scrapeShopeeProduct(url: string) {
   }
 }
 
-async function pollForResult(taskId: string, maxAttempts: number = 8): Promise<any> {
+async function pollForResult(taskId: string, url: string, maxAttempts: number = 8): Promise<any> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     console.log(`🔄 Polling attempt ${attempt}/${maxAttempts}...`)
 
@@ -184,7 +184,7 @@ async function pollForResult(taskId: string, maxAttempts: number = 8): Promise<a
       // Check if task is completed
       if (resultData.success === true && resultData.state === 'completed') {
         console.log('✅ Task completed!')
-        return processScrapelessData(resultData)
+        return processScrapelessData(resultData, url)
       } else if (resultData.success === false || resultData.state === 'failed') {
         console.error('❌ Task failed:', resultData.status || resultData.error)
         return null
@@ -207,7 +207,7 @@ async function pollForResult(taskId: string, maxAttempts: number = 8): Promise<a
   return null
 }
 
-function processScrapelessData(data: any) {
+function processScrapelessData(data: any, url: string) {
   console.log('🔍 Processing Scrapeless data:', JSON.stringify(data, null, 2))
   
   // Check if response has base64 encoded data (from webhook format)
@@ -339,7 +339,8 @@ function processScrapelessData(data: any) {
     description: cleanText(description),
     images: images,
     brand: cleanText(brand),
-    category: cleanText(category)
+    category: cleanText(category),
+    productUrl: url
   }
 
   console.log('✅ Cleaned product data:', cleanedProduct)
@@ -382,7 +383,8 @@ function createMockProductData(url: string) {
       'https://via.placeholder.com/300x300/EC4899/FFFFFF?text=Product+Image+3'
     ],
     brand: 'Demo Brand',
-    category: 'Áo thun'
+    category: 'Áo thun',
+    productUrl: url
   }
 }
 

--- a/src/components/FashionChatbot.tsx
+++ b/src/components/FashionChatbot.tsx
@@ -36,6 +36,7 @@ interface ProductData {
   images: string[]
   brand?: string
   category?: string
+  productUrl?: string
 }
 
 interface FashionAdvice {
@@ -94,6 +95,44 @@ export default function FashionChatbot() {
     const encodedImageUrl = encodeURIComponent(imageUrl)
     router.push(`/try-on?clothing=${encodedImageUrl}`)
     toast.success('Chuyển đến trang thử đồ ảo...')
+  }
+
+  const handleOpenProduct = (productUrl?: string) => {
+    if (!productUrl) {
+      toast.error('Không có link sản phẩm để mở')
+      return
+    }
+
+    if (typeof window !== 'undefined') {
+      window.open(productUrl, '_blank', 'noopener,noreferrer')
+    }
+  }
+
+  const handleCopyProductUrl = async (productUrl?: string) => {
+    if (!productUrl) {
+      toast.error('Không có link sản phẩm để sao chép')
+      return
+    }
+
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(productUrl)
+      } else {
+        const textArea = document.createElement('textarea')
+        textArea.value = productUrl
+        textArea.style.position = 'fixed'
+        textArea.style.opacity = '0'
+        document.body.appendChild(textArea)
+        textArea.focus()
+        textArea.select()
+        document.execCommand('copy')
+        document.body.removeChild(textArea)
+      }
+      toast.success('Đã sao chép link sản phẩm!')
+    } catch (error) {
+      console.error('Error copying product URL:', error)
+      toast.error('Không thể sao chép link sản phẩm')
+    }
   }
 
   // Save messages to localStorage whenever messages change
@@ -393,11 +432,18 @@ export default function FashionChatbot() {
                           </svg>
                           Thử đồ ảo
                         </button>
-                        <button className="flex-1 bg-gradient-to-r from-purple-500 to-pink-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:from-purple-600 hover:to-pink-600 transition-all">
+                        <button
+                          onClick={() => handleOpenProduct(message.product?.productUrl)}
+                          className="flex-1 bg-gradient-to-r from-purple-500 to-pink-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:from-purple-600 hover:to-pink-600 transition-all"
+                        >
                           <ShoppingBagIcon className="w-4 h-4 inline mr-2" />
                           Mua ngay
                         </button>
-                        <button className="px-4 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50">
+                        <button
+                          onClick={() => handleCopyProductUrl(message.product?.productUrl)}
+                          className="px-4 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50"
+                          title="Sao chép link sản phẩm"
+                        >
                           <LinkIcon className="w-4 h-4" />
                         </button>
                       </div>


### PR DESCRIPTION
## Summary
- include the original Shopee link when scraping or mocking product data so it can be reused by the UI
- extend the fashion chatbot product typing and add helpers to open or copy the Shopee link from each result

## Testing
- npm run lint *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ca56714e5083268e342ab9e74a202b